### PR TITLE
[fix] bug: divide by zero

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -76,7 +76,9 @@ def save_best_record_thumos(test_info, file_path):
 def minmax_norm(act_map):
     max_val = nn.ReLU()(torch.max(act_map, dim=1)[0])
     min_val = nn.ReLU()(torch.min(act_map, dim=1)[0])
-    ret = (act_map - min_val) / (max_val - min_val)
+    delta = max_val - min_val
+    delta[delta <=0] = 1
+    ret = (act_map - min_val) / delta
 
     return ret
 


### PR DESCRIPTION
I manually change the negative denominator to 1

The original score, (before f52240e) :
(mAP 0.1:0.9)
0.58165601 0.52299187 0.44567186 0.36029029 0.26995191 0.18586732  0.10439362 0.03878143 0.00472061

After f52240e
0.58102928 0.52256658 0.44575624 0.36000879 0.26955417 0.18539184 0.10408522 0.0387514  0.00471491


PR:
0.58102928 0.52256658 0.44575624 0.36000879 0.26955417 0.18539184  0.10408522 0.0387514  0.00471491